### PR TITLE
set compiler fno-pic explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,7 @@ ASFLAGS			+= 	-nostdinc -ffreestanding -Wa,--fatal-warnings	\
 CFLAGS			+= 	-nostdinc -ffreestanding -Wall			\
 				-Werror -Wmissing-include-dirs			\
 				-mgeneral-regs-only -mstrict-align		\
-				-std=c99 -c -Os	${DEFINES} ${INCLUDES}
+				-std=c99 -c -Os	${DEFINES} ${INCLUDES} -fno-pic
 CFLAGS			+=	-ffunction-sections -fdata-sections		\
 				-fno-delete-null-pointer-checks
 


### PR DESCRIPTION
Android toolchain is build with fpic enabled by default
hence explicitly disabling that.

Signed-off-by: Vishal Bhoj vishal.bhoj@linaro.org
