### PR TITLE
hikey: Change product response to "hikey"

### DIFF
--- a/plat/hikey/usb.c
+++ b/plat/hikey/usb.c
@@ -1281,7 +1281,7 @@ static void fb_getvar(char *cmdbuf)
 		tx_status(response);
 		rx_cmd();
 	} else if (!strncmp(cmdbuf + 7, "product", 8)) {
-		bytes = sprintf(response, "OKAYHisilicon HiKey");
+		bytes = sprintf(response, "OKAYhikey");
 		response[bytes] = '\0';
 		tx_status(response);
 		rx_cmd();


### PR DESCRIPTION
$ fastboot getvar product - should be consistent with
ro.product.device value that is set from the build.

Change-Id: Ib927ea292f20baaeaa7d295a1d113fe35719613d
Signed-off-by: Dmitry Shmidt dimitrysh@google.com
