### PR TITLE
HiKey: usb: return bootloader version as 0.4

### DIFF
--- a/plat/hikey/usb.c
+++ b/plat/hikey/usb.c
@@ -47,6 +47,8 @@
 
 #define USB_BLOCK_HIGH_SPEED_SIZE	512
 
+#define VERSION_BOOTLOADER	"0.4"
+
 struct ep_type {
 	unsigned char		active;
 	unsigned char		busy;
@@ -1271,7 +1273,7 @@ static void fb_getvar(char *cmdbuf)
 		tx_status(response);
 		rx_cmd();
 	} else if (!strncmp(cmdbuf + 7, "version-bootloader", 18)) {
-		bytes = sprintf(response, "OKAY%s", version_string);
+		bytes = sprintf(response, "OKAY%s", VERSION_BOOTLOADER);
 		response[bytes] = '\0';
 		tx_status(response);
 		rx_cmd();


### PR DESCRIPTION
The bootloader version should be same in arm-trusted-firmware
and edk2. It is 0.4 in edk2 and hence setting the same
here for all the checks to pass while flashing.

Change-Id: I35848c08eb07ddb0d6895ddd49988488276913a4
Signed-off-by: Vishal Bhoj vishal.bhoj@linaro.org
