### PR TITLE
bl1_plat_setup: enable ldo21

### DIFF
--- a/plat/hikey/bl1_plat_setup.c
+++ b/plat/hikey/bl1_plat_setup.c
@@ -384,6 +384,12 @@ static void hikey_hi6553_init(void)
 	hi6553_write_8(LDO15_REG_ADJ, data);
 	hi6553_write_8(ENABLE3_LDO9_16, 1 << 6);
 	mdelay(5);
+	/* enable LDO21 */
+	data = hi6553_read_8(LDO21_REG_ADJ);
+	data = (data & 0xf8) | 0x3;
+	hi6553_write_8(LDO21_REG_ADJ, data);
+	hi6553_write_8(ENABLE4_LDO17_22, 1 << 4);
+	mdelay(5);
 	/* enable LDO22 */
 	data = hi6553_read_8(LDO22_REG_ADJ);
 	data = (data & 0xf8) | 0x7;

--- a/plat/hikey/include/hi6553.h
+++ b/plat/hikey/include/hi6553.h
@@ -70,6 +70,7 @@
 #define LDO15_REG_ADJ				0x080
 #define LDO19_REG_ADJ				0x084
 #define LDO20_REG_ADJ				0x085
+#define LDO21_REG_ADJ				0x086
 #define LDO22_REG_ADJ				0x087
 #define DR_LED_CTRL				0x098
 #define DR_OUT_CTRL				0x099


### PR DESCRIPTION
LDO21 is 1.8v source (pin 35) on the LS connector. Mezzanine cards
usually use this to source level shifters for UART, GPIO, SPI, I2C,
etc so if not enabled, connected peripherals will not work either
(during bootloader stage) until linux is booted.

Signed-off-by: Victor Chong <victor.chong@linaro.org>