### PR TITLE
hikey: Disable VBUS_DET interrupt for PMIC

### DIFF
--- a/plat/hikey/bl1_plat_setup.c
+++ b/plat/hikey/bl1_plat_setup.c
@@ -399,6 +399,11 @@ static void hikey_hi6553_init(void)
 
 	/* select 32.764KHz */
 	hi6553_write_8(CLK19M2_600_586_EN, 0x01);
+
+	/* Disable PMIC internal interrupt */
+	data = hi6553_read_8(IRQ2_MASK);
+	data = data | 0x3;
+	hi6553_write_8(IRQ2_MASK, data);
 }
 
 static void hikey_gpio_init(void)
@@ -430,6 +435,10 @@ static void hikey_gpio_init(void)
 	gpio_direction_output(33);
 	gpio_direction_output(34);
 	gpio_direction_output(35);
+
+	/* Clear GPIO5 and GPIO6 interrutps */
+	mmio_write_32(GPIO5_BASE + 0x41C, 0xFF);
+	mmio_write_32(GPIO6_BASE + 0x41C, 0xFF);
 
 	/* Initialize PWR_HOLD GPIO */
 	gpio_set_value(0, 1);

--- a/plat/hikey/include/hi6553.h
+++ b/plat/hikey/include/hi6553.h
@@ -41,6 +41,7 @@
 #define DISABLE6_XO_CLK_RF2			(1 << 4)
 
 #define VERSION_REG				0x000
+#define IRQ2_MASK				0x008
 #define ENABLE2_LDO1_8				0x029
 #define DISABLE2_LDO1_8				0x02a
 #define ONOFF_STATUS2_LDO1_8			0x02b


### PR DESCRIPTION
[   40.835279] irq 57: nobody cared (try booting with the "irqpoll" option)
[   40.842075] CPU: 0 PID: 980 Comm: irq/57-hi655x-p Not tainted 4.4.77-568944-g576a0114dec8-dirty #667
[   40.851303] Hardware name: HiKey Development Board (DT)
[   40.856580] Call trace:
[   40.859060] [<ffffff800808c4cc>] dump_backtrace+0x0/0x1e0
[   40.864516] [<ffffff800808c8ac>] show_stack+0x20/0x28
[   40.869622] [<ffffff80084b9688>] dump_stack+0xa8/0xe0
[   40.874729] [<ffffff800812dd5c>] __report_bad_irq+0x40/0xec
[   40.880360] [<ffffff800812e0bc>] note_interrupt+0x1e4/0x2d8
[   40.885992] [<ffffff800812b11c>] handle_irq_event_percpu+0xd8/0x268
[   40.892324] [<ffffff800812b2f8>] handle_irq_event+0x4c/0x7c
[   40.897955] [<ffffff800812ecbc>] handle_level_irq+0xcc/0x178
[   40.903672] [<ffffff800812a778>] generic_handle_irq+0x34/0x4c
[   40.909481] [<ffffff80085074c8>] pl061_irq_handler+0xa8/0x124
[   40.915286] [<ffffff800812a778>] generic_handle_irq+0x34/0x4c
[   40.921092] [<ffffff800812a820>] __handle_domain_irq+0x90/0xf8
[   40.926985] [<ffffff8008082620>] gic_handle_irq+0x58/0xa8

Change-Id: I233e2f1382124d27e1f8183b9664c4991ee3cf1d
Signed-off-by: Dmitry Shmidt <dimitrysh@google.com>
Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>