### PR TITLE
Hikey960: Fix hikey960 pcie mount fail

### DIFF
--- a/plat/hisilicon/hikey960/hikey960_bl1_setup.c
+++ b/plat/hisilicon/hikey960/hikey960_bl1_setup.c
@@ -642,6 +642,8 @@ static void hikey960_pinmux_init(void)
 	}
 	/* GPIO005 - PMU SSI, 10mA */
 	mmio_write_32(IOCG_006_REG, 2 << 4);
+	/* GPIO213 - PCIE_CLKREQ_N */
+	mmio_write_32(IOMG_AO_033_REG, 1);
 }
 
 /*

--- a/plat/hisilicon/hikey960/include/hi3660.h
+++ b/plat/hisilicon/hikey960/include/hi3660.h
@@ -335,6 +335,8 @@
 #define IOMG_AO_026_REG			(IOMG_AO_REG_BASE + 0x068)
 /* GPIO219: PD interrupt. pull up */
 #define IOMG_AO_039_REG			(IOMG_AO_REG_BASE + 0x09C)
+/* GPIO213: PCIE_CLKREQ_N */
+#define IOMG_AO_033_REG			(IOMG_AO_REG_BASE + 0x084)
 
 #define IOCG_AO_REG_BASE		0xFFF1187C
 /* GPIO219: PD interrupt. pull up */


### PR DESCRIPTION
Set IOC_AO_IOMG_033 function from GPIO213 to PCIE_CLKREQ_N

bit[0-2]:  000: GPIO_213;
           001: PCIE_CLKREQ_N;
           010: GPIO_018_SH;
           100: GPIO_014_SE;
           110: FAC_TEST24;
           111: FAC_TEST24;
bit[3-31]: reserved

Signed-off-by: Guangtao Zhang <zhangguangtao@hisilicon.com>
Tested-by: Yao Chen <chenyao11@huawei.com>
Acked-by: Haojian Zhuang <haojian.zhuang@linaro.org>