### PR TITLE
HACK: Workaround horizontal offset issue from psci

### DIFF
--- a/lib/psci/psci_suspend.c
+++ b/lib/psci/psci_suspend.c
@@ -147,6 +147,8 @@ void psci_cpu_suspend_start(entry_point_info_t *ep,
 	int skip_wfi = 0;
 	unsigned int idx = plat_my_core_pos();
 
+	if (is_power_down_state)
+		return;
 	/*
 	 * This function must only be called on platforms where the
 	 * CPU_SUSPEND platform hooks have been implemented.


### PR DESCRIPTION
Despite a fair amount of debugging, we've been unable to
figure out why enabling PSCI suspend is causing the
graphics horizontal offset glitches when certain memory
operations occur (triggered by antutu's memory test,
or even memtest madvise, or using memset).

So for now, in order to unblock moving to newer kernels,
disable PSCI suspend to avoid this issue.

Change-Id: Ib2a538789d2a45a4830ba29f08c8c1fad11484e0
Signed-off-by: John Stultz <john.stultz@linaro.org>